### PR TITLE
Adding support to display or hide hours, minutes and seconds

### DIFF
--- a/js/jquery.chrony.js
+++ b/js/jquery.chrony.js
@@ -80,8 +80,22 @@
 					id = 'chrony-' + $this.index();
 					$this.attr('id', id); 
 				}
-
-				$this.append($hour).append(separator).append($minute).append(separator).append($second);
+				
+				if (opt.displayHours) {
+					$this.append($hour);
+					if (opt.displayMinutes || opt.displaySeconds) {
+						$this.append(separator);
+					}
+				}
+				if (opt.displayMinutes) {
+					$this.append($minute)
+					if (opt.displaySeconds) {
+						$this.append(separator);
+					}
+				}
+				if (opt.displaySeconds) {
+					$this.append($second);
+				}
 
 				var $separators = $this.children('span');
 
@@ -185,6 +199,9 @@
 		decrement:	1,
 		hour:		0,
 		hours:		undefined,
+		displayHours: true,
+		displayMinutes: true,
+		displaySeconds: true,
 		minute:		0,
 		minutes:	undefined,
 		second:		0,

--- a/test/spec.js
+++ b/test/spec.js
@@ -307,6 +307,74 @@ describe('Chrony', function() {
 			jasmine.Clock.tick(1000 * 60 * 60);
 			expect($time).toHaveAttr('style', 'color: rgb(0, 255, 0);');
 		});
+		
+		it('should not display hours digits', function() {
+			// given
+			var $time = $('#time');
+
+			// when
+			$time.chrony({ minutes: 20, displayHours: false});
+			$firstColon		= $time.children('span').eq(0),
+			$secondColon		= $time.children('span').eq(1),
+
+			// then
+			expect($time).not.toContain('div#hour');
+		  expect($time).toContain('div#minute');
+		  expect($time).toContain('div#second');
+			expect($firstColon).toExist();
+			expect($secondColon).not.toExist();
+		});
+		
+		it('should not display minutes digits', function() {
+			// given
+			var $time = $('#time');
+
+			// when
+			$time.chrony({ seconds: 20, displayMinutes: false});
+			$firstColon		= $time.children('span').eq(0),
+			$secondColon		= $time.children('span').eq(1),
+
+			// then
+			expect($time).toContain('div#hour');
+		  expect($time).not.toContain('div#minute');
+		  expect($time).toContain('div#second');
+			expect($firstColon).toExist();
+			expect($secondColon).not.toExist();
+		});
+		
+		it('should not display seconds digits', function() {
+			// given
+			var $time = $('#time');
+
+			// when
+			$time.chrony({ minutes: 20, displaySeconds: false});
+			$firstColon		= $time.children('span').eq(0),
+			$secondColon		= $time.children('span').eq(1),
+
+			// then
+			expect($time).toContain('div#hour');
+		  expect($time).toContain('div#minute');
+		  expect($time).not.toContain('div#second');
+			expect($firstColon).toExist();
+			expect($secondColon).not.toExist();
+		});
+		
+		it('should not display minutes and seconds digits', function() {
+			// given
+			var $time = $('#time');
+
+			// when
+			$time.chrony({ hours: 20, displayMinutes: false, displaySeconds: false});
+			$firstColon		= $time.children('span').eq(0),
+			$secondColon		= $time.children('span').eq(1),
+
+			// then
+			expect($time).toContain('div#hour');
+		  expect($time).not.toContain('div#minute');
+		  expect($time).not.toContain('div#second');
+			expect($firstColon).not.toExist();
+			expect($secondColon).not.toExist();
+		});
 
 	});
 


### PR DESCRIPTION
Hi, :)

I made a modification to lib adding three new properties: displayHours, displayMinutes and displayMinutes. The behavior expected is hide the digits that we cannot want in the timer.

The properties starts as true by default.

Example of use:

``` javascript
$('#timer > h1').chrony({
    minutes: 25,
    displayHours: false
});
```

Result:

``` html
<h1 id="chrony-0">
<div id="minute" style="float: left;">24</div>
<span style="float: left;">:</span>
<div id="second" style="float: left;">40</div>
</h1>
```

I add some tests to test suites and that's it. :)

"Simbora"
